### PR TITLE
Update transforms.Scale to transforms.Resize

### DIFF
--- a/ACGPN_train/data/base_dataset.py
+++ b/ACGPN_train/data/base_dataset.py
@@ -42,7 +42,7 @@ def get_transform(opt, params, method=Image.BICUBIC, normalize=True):
     elif 'scale_width' in opt.resize_or_crop:
         transform_list.append(transforms.Lambda(lambda img: __scale_width(img, opt.loadSize, method)))
         osize = [256,192]
-        transform_list.append(transforms.Scale(osize, method))  
+        transform_list.append(transforms.Resize(osize, method))  
     if 'crop' in opt.resize_or_crop:
         transform_list.append(transforms.Lambda(lambda img: __crop(img, params['crop_pos'], opt.fineSize)))
 


### PR DESCRIPTION
transform.Scale has been deprecated in favor of resize https://discuss.pytorch.org/t/attributeerror-module-torchvision-transforms-has-no-attribute-scale/146687